### PR TITLE
Final minor updates based copilot review of pull request 32.

### DIFF
--- a/DHI.Mike1D.Examples/UnitTestHelper.cs
+++ b/DHI.Mike1D.Examples/UnitTestHelper.cs
@@ -15,6 +15,6 @@ namespace DHI.Mike1D.Examples
         /// <summary>
         /// Path to test data
         /// </summary>
-        public static string TestDataRoot => new Uri(Path.Combine(TestContext.CurrentContext.TestDirectory, TestDataRootRelative)).LocalPath;
+        public static string TestDataRoot => Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, TestDataRootRelative));
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An introduction to the MIKE 1D API can be found on:
 
 http://docs.mikepoweredbydhi.com/engine_libraries/mike1d/mike1d_api/
 
-And a overview of the entire MIKE 1D engine and API can be found here:
+And an overview of the entire MIKE 1D engine and API can be found here:
 
 https://manuals.mikepoweredbydhi.help/latest/General/Class_Library/DHI_MIKE1D/html/R_Project_DHI_Mike1D.htm
 

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,4 +1,3 @@
-@@ -0,0 +1,9 @@
 *Result Files
 CrossSection/*-cs*.xns11
 Results/*test*


### PR DESCRIPTION
- Update to UnitTestHelper:
Building the test data path via new Uri(...).LocalPath can throw on non-Windows paths (e.g., new Uri("/home/..." ) is treated as a relative URI and LocalPath is invalid). Prefer Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, TestDataRootRelative)) (and avoid Uri entirely) to make this robust across environments.

- Clean up of README and data/.gitignore files